### PR TITLE
Add SQLite metadata storage

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -16,3 +16,6 @@ rustls = "0.23"
 rustls-pemfile = "1"
 rand = "0.8"
 rusqlite = { version = "0.36", features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,3 +15,4 @@ tokio-rustls = "0.26"
 rustls = "0.23"
 rustls-pemfile = "1"
 rand = "0.8"
+rusqlite = { version = "0.31", features = ["bundled"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,4 +15,4 @@ tokio-rustls = "0.26"
 rustls = "0.23"
 rustls-pemfile = "1"
 rand = "0.8"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.36", features = ["bundled"] }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,13 +1,13 @@
 pub mod exec;
 pub mod file;
 pub mod imap;
+pub mod metadata;
 pub mod mime;
 pub mod tls;
-pub mod metadata;
 
 pub use exec::*;
 pub use file::*;
 pub use imap::*;
+pub use metadata::*;
 pub use mime::*;
 pub use tls::*;
-pub use metadata::*;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -3,9 +3,11 @@ pub mod file;
 pub mod imap;
 pub mod mime;
 pub mod tls;
+pub mod metadata;
 
 pub use exec::*;
 pub use file::*;
 pub use imap::*;
 pub use mime::*;
 pub use tls::*;
+pub use metadata::*;

--- a/crates/utils/src/metadata.rs
+++ b/crates/utils/src/metadata.rs
@@ -56,8 +56,11 @@ impl EmailMetadata {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use rusqlite::{params, Connection};
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
+
+    use super::EmailMetadata;
 
     #[test]
     fn test_email_metadata_new() {

--- a/crates/utils/src/metadata.rs
+++ b/crates/utils/src/metadata.rs
@@ -2,34 +2,54 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use rusqlite::{params, Connection};
+use tokio::task::spawn_blocking;
 
 #[derive(Clone)]
 pub struct EmailMetadata {
     pub message_id: String,
-    pub sender: String,
-    pub recipient: String,
+    pub from: String,
+    pub rcpt: String,
     pub subject: String,
     pub path: PathBuf,
 }
 
-pub async fn store_metadata(
-    db: impl AsRef<Path>,
-    meta: &EmailMetadata,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let path = db.as_ref().to_path_buf();
-    let meta = meta.clone();
-    tokio::task::spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
-        let conn = Connection::open(path)?;
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS metadata (id TEXT PRIMARY KEY, sender TEXT, recipient TEXT, subject TEXT, path TEXT)",
-            [],
-        )?;
-        conn.execute(
-            "INSERT INTO metadata (id, sender, recipient, subject, path) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![meta.message_id, meta.sender, meta.recipient, meta.subject, meta.path.to_string_lossy()],
-        )?;
+impl EmailMetadata {
+    pub fn new(
+        message_id: String,
+        from: String,
+        rcpt: String,
+        subject: String,
+        path: PathBuf,
+    ) -> Self {
+        Self {
+            message_id,
+            from,
+            rcpt,
+            subject,
+            path,
+        }
+    }
+
+    pub async fn store_sqlite(
+        &self,
+        db: impl AsRef<Path>,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let path = db.as_ref().to_path_buf();
+        let metadata = self.clone();
+
+        spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
+            let conn = Connection::open(path)?;
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS metadata (id TEXT PRIMARY KEY, sender TEXT, recipient TEXT, subject TEXT, path TEXT)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO metadata (id, sender, recipient, subject, path) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![metadata.message_id, metadata.from, metadata.rcpt, metadata.subject, metadata.path.to_string_lossy()],
+            )?;
+            Ok(())
+        })
+        .await??;
         Ok(())
-    })
-    .await??;
-    Ok(())
+    }
 }

--- a/crates/utils/src/metadata.rs
+++ b/crates/utils/src/metadata.rs
@@ -5,7 +5,7 @@ use rusqlite::{params, Connection};
 
 #[derive(Clone)]
 pub struct EmailMetadata {
-    pub id: String,
+    pub message_id: String,
     pub sender: String,
     pub recipient: String,
     pub subject: String,
@@ -26,7 +26,7 @@ pub async fn store_metadata(
         )?;
         conn.execute(
             "INSERT INTO metadata (id, sender, recipient, subject, path) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![meta.id, meta.sender, meta.recipient, meta.subject, meta.path.to_string_lossy()],
+            params![meta.message_id, meta.sender, meta.recipient, meta.subject, meta.path.to_string_lossy()],
         )?;
         Ok(())
     })

--- a/crates/utils/src/metadata.rs
+++ b/crates/utils/src/metadata.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use rusqlite::{params, Connection};
 use tokio::task::spawn_blocking;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EmailMetadata {
     pub message_id: String,
     pub from: String,
@@ -37,20 +37,51 @@ impl EmailMetadata {
         let path = db.as_ref().to_path_buf();
         let metadata = self.clone();
 
+        // spawns a blocking task to store the metadata in the database
+        // this is done to avoid blocking the main thread
         spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
             let conn = Connection::open(path)?;
             conn.execute(
-                "CREATE TABLE IF NOT EXISTS metadata (id TEXT PRIMARY KEY, sender TEXT, recipient TEXT, subject TEXT, path TEXT)",
+                "CREATE TABLE IF NOT EXISTS metadata (message_id TEXT PRIMARY KEY, _from TEXT, rcpt TEXT, subject TEXT, path TEXT)",
                 [],
             )?;
             conn.execute(
-                "INSERT INTO metadata (id, sender, recipient, subject, path) VALUES (?1, ?2, ?3, ?4, ?5)",
+                "INSERT INTO metadata (message_id, _from, rcpt, subject, path) VALUES (?1, ?2, ?3, ?4, ?5)",
                 params![metadata.message_id, metadata.from, metadata.rcpt, metadata.subject, metadata.path.to_string_lossy()],
             )?;
             Ok(())
         })
         .await??;
         Ok(())
+    }
+
+    pub async fn retrieve_sqlite(
+        db: impl AsRef<Path>,
+        message_id: String,
+    ) -> Result<EmailMetadata, Box<dyn Error + Send + Sync>> {
+        let path = db.as_ref().to_path_buf();
+
+        // spawns a blocking task to retrieve the metadata from the database
+        // this is done to avoid blocking the main thread
+        spawn_blocking(
+            move || -> Result<EmailMetadata, Box<dyn Error + Send + Sync>> {
+                let conn = Connection::open(path)?;
+                let mut stmt = conn.prepare(
+                    "SELECT message_id, _from, rcpt, subject, path FROM metadata WHERE message_id = ?",
+                )?;
+                let row = stmt.query_row(params![message_id], |row| {
+                    Ok(EmailMetadata {
+                        message_id: row.get(0)?,
+                        from: row.get(1)?,
+                        rcpt: row.get(2)?,
+                        subject: row.get(3)?,
+                        path: PathBuf::from(row.get::<_, String>(4)?),
+                    })
+                })?;
+                Ok(row)
+            },
+        )
+        .await?
     }
 }
 
@@ -122,7 +153,9 @@ mod tests {
 
         let conn = Connection::open(db_path).unwrap();
         let mut stmt = conn
-            .prepare("SELECT id, sender, recipient, subject, path FROM metadata WHERE id = ?")
+            .prepare(
+                "SELECT message_id, _from, rcpt, subject, path FROM metadata WHERE message_id = ?",
+            )
             .unwrap();
 
         let row = stmt
@@ -236,7 +269,9 @@ mod tests {
 
         let conn = Connection::open(db_path).unwrap();
         let mut stmt = conn
-            .prepare("SELECT id, sender, recipient, subject, path FROM metadata WHERE id = ?")
+            .prepare(
+                "SELECT message_id, _from, rcpt, subject, path FROM metadata WHERE message_id = ?",
+            )
             .unwrap();
         let row = stmt
             .query_row(params!["test-id-with-special-chars"], |row| {
@@ -272,6 +307,57 @@ mod tests {
         assert!(
             result.is_err(),
             "Should fail when trying to create database in nonexistent directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_sqlite_success() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path();
+
+        let original_metadata = EmailMetadata::new(
+            "retrieve-test-id".to_string(),
+            "sender@example.com".to_string(),
+            "recipient@example.com".to_string(),
+            "Test Subject for Retrieval".to_string(),
+            PathBuf::from("/path/to/email.eml"),
+        );
+
+        // First store the metadata
+        let store_result = original_metadata.store_sqlite(db_path).await;
+        assert!(
+            store_result.is_ok(),
+            "Failed to store metadata: {:?}",
+            store_result
+        );
+
+        // Then retrieve it
+        let retrieved_metadata =
+            EmailMetadata::retrieve_sqlite(db_path, "retrieve-test-id".to_string()).await;
+        assert!(
+            retrieved_metadata.is_ok(),
+            "Failed to retrieve metadata: {:?}",
+            retrieved_metadata
+        );
+
+        let retrieved = retrieved_metadata.unwrap();
+        assert_eq!(retrieved.message_id, original_metadata.message_id);
+        assert_eq!(retrieved.from, original_metadata.from);
+        assert_eq!(retrieved.rcpt, original_metadata.rcpt);
+        assert_eq!(retrieved.subject, original_metadata.subject);
+        assert_eq!(retrieved.path, original_metadata.path);
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_sqlite_not_found() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path();
+
+        // Try to retrieve non-existent metadata
+        let result = EmailMetadata::retrieve_sqlite(db_path, "non-existent-id".to_string()).await;
+        assert!(
+            result.is_err(),
+            "Should fail when trying to retrieve non-existent metadata"
         );
     }
 }

--- a/crates/utils/src/metadata.rs
+++ b/crates/utils/src/metadata.rs
@@ -1,0 +1,35 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection};
+
+#[derive(Clone)]
+pub struct EmailMetadata {
+    pub id: String,
+    pub sender: String,
+    pub recipient: String,
+    pub subject: String,
+    pub path: PathBuf,
+}
+
+pub async fn store_metadata(
+    db: impl AsRef<Path>,
+    meta: &EmailMetadata,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let path = db.as_ref().to_path_buf();
+    let meta = meta.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
+        let conn = Connection::open(path)?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS metadata (id TEXT PRIMARY KEY, sender TEXT, recipient TEXT, subject TEXT, path TEXT)",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO metadata (id, sender, recipient, subject, path) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![meta.id, meta.sender, meta.recipient, meta.subject, meta.path.to_string_lossy()],
+        )?;
+        Ok(())
+    })
+    .await??;
+    Ok(())
+}

--- a/imap/src/main.rs
+++ b/imap/src/main.rs
@@ -42,7 +42,7 @@ impl IMAPSession {
                     writer,
                     tag,
                     "BAD",
-                    format!("Unknown command ({})", command).as_str(),
+                    format!("Unknown command ({command})").as_str(),
                 )
                 .await
             }
@@ -216,7 +216,7 @@ impl IMAPSession {
     ) -> Result<(), Box<dyn Error>> {
         if parts.len() >= 2 {
             let mailbox = parts[2].trim_matches('"').to_string();
-            let path = self.mailbox_path().join(format!("{}.mbox", mailbox));
+            let path = self.mailbox_path().join(format!("{mailbox}.mbox"));
             create_dir_all(path).await?;
             self.write_response(writer, tag, "OK", "CREATE completed")
                 .await?;
@@ -241,7 +241,7 @@ impl IMAPSession {
                     writer,
                     tag,
                     "BAD",
-                    &format!("Invalid UID command {}", uid_command),
+                    &format!("Invalid UID command {uid_command}"),
                 )
                 .await?;
             }
@@ -352,7 +352,7 @@ impl IMAPSession {
     }
 
     async fn fetch_message(&self, message_id: &str) -> Result<String, Box<dyn Error>> {
-        let path = self.mailbox_path().join(format!("{}.eml", message_id));
+        let path = self.mailbox_path().join(format!("{message_id}.eml"));
         let content = read_to_string(path).await?;
         Ok(content)
     }
@@ -370,7 +370,7 @@ impl IMAPSession {
         message: &str,
     ) {
         writer
-            .write_all(format!("{} {} {}\r\n", tag, result, message).as_bytes())
+            .write_all(format!("{tag} {result} {message}\r\n").as_bytes())
             .await
             .ok();
     }
@@ -382,7 +382,7 @@ impl IMAPSession {
         result: &str,
         message: &str,
     ) -> Result<(), Box<dyn Error>> {
-        println!(">> {} {} {}", tag, result, message);
+        println!(">> {tag} {result} {message}");
         self.write_inner(w, tag, result, message).await;
         Ok(())
     }
@@ -407,7 +407,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|_| PORT.to_string())
         .parse()
         .unwrap();
-    let listening = format!("{}:{}", host, port);
+    let listening = format!("{host}:{port}");
     let listener = TcpListener::bind(&listening).await?;
 
     println!("Mailsis-IMAP running on {}", &listening);

--- a/smtp/examples/smtp_client.rs
+++ b/smtp/examples/smtp_client.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let start_time = Instant::now();
 
     // Generate random file
-    println!("Generating random file of {} MB...", FILE_SIZE_MB);
+    println!("Generating random file of {FILE_SIZE_MB} MB...");
     let file_path = "random_data.bin";
     generate_random_file(file_path, FILE_SIZE_MB).await?;
     println!("File generated in {:?}", start_time.elapsed());
@@ -59,8 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     lettre::message::SinglePart::builder()
                         .header(header::ContentType::TEXT_PLAIN)
                         .body(format!(
-                            "This is a test email with a {} MB file attachment.",
-                            FILE_SIZE_MB
+                            "This is a test email with a {FILE_SIZE_MB} MB file attachment."
                         )),
                 )
                 .singlepart(

--- a/smtp/examples/smtp_raw.rs
+++ b/smtp/examples/smtp_raw.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let (file_data, filename) = if args().len() > 1 {
         let path = args().nth(1).unwrap();
-        println!("Reading file from {}", path);
+        println!("Reading file from {path}");
         let filename = Path::new(&path)
             .file_name()
             .unwrap_or_default()
@@ -84,20 +84,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                   From: sender@localhost\r\n\
                   To: recipient@localhost\r\n\
                   Subject: Test Email with Large Attachment\r\n\
-                  Content-Type: multipart/mixed; boundary=\"{}\"\r\n\
+                  Content-Type: multipart/mixed; boundary=\"{boundary}\"\r\n\
                   \r\n\
                   \r\n\
-                  --{}\r\n\
+                  --{boundary}\r\n\
                   Content-Type: text/plain\r\n\
                   \r\n\
                   This is a test email with a large attachment.\r\n\
                   \r\n\
-                  --{}\r\n\
+                  --{boundary}\r\n\
                   Content-Type: application/octet-stream\r\n\
                   Content-Transfer-Encoding: base64\r\n\
-                  Content-Disposition: attachment; filename=\"{}\"\r\n\
-                  \r\n",
-            boundary, boundary, boundary, filename
+                  Content-Disposition: attachment; filename=\"{filename}\"\r\n\
+                  \r\n"
         ),
     )
     .await?;
@@ -111,7 +110,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Data sent in {:?}", send_start.elapsed());
 
     // Send the final boundary and end of message
-    write_data(&mut writer, &format!("\r\n--{}--\r\n.\r\n", boundary)).await?;
+    write_data(&mut writer, &format!("\r\n--{boundary}--\r\n.\r\n")).await?;
     read_response(&mut reader, &mut response).await?;
 
     // Send QUIT command
@@ -125,9 +124,9 @@ async fn write_command<W: AsyncWrite + Unpin>(
     writer: &mut W,
     message: &str,
 ) -> Result<(), Box<dyn Error>> {
-    println!(">> {}", message);
+    println!(">> {message}");
     writer
-        .write_all(format!("{}\r\n", message).as_bytes())
+        .write_all(format!("{message}\r\n").as_bytes())
         .await?;
     Ok(())
 }

--- a/smtp/src/main.rs
+++ b/smtp/src/main.rs
@@ -1,8 +1,7 @@
 use base64::{engine::general_purpose, Engine as _};
 use chrono::Utc;
 use mailsis_utils::{
-    get_crate_root, is_mime_valid, load_tls_server_config, parse_mime_headers, store_metadata,
-    EmailMetadata,
+    get_crate_root, is_mime_valid, load_tls_server_config, parse_mime_headers, EmailMetadata,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -589,8 +588,7 @@ async fn store_email(
     if !is_mime_valid(&body).await {
         file.write_all(format!("From: {from}\r\n").as_bytes())
             .await?;
-        file.write_all(format!("To: {rcpt}\r\n").as_bytes())
-            .await?;
+        file.write_all(format!("To: {rcpt}\r\n").as_bytes()).await?;
         file.write_all(format!("Date: {}\r\n\r\n", Utc::now().to_rfc2822()).as_bytes())
             .await?;
     }
@@ -602,15 +600,9 @@ async fn store_email(
     if store_meta {
         let headers = parse_mime_headers(&body).unwrap_or_default();
         let subject = headers.get("Subject").cloned().unwrap_or_default();
-        let metadata = EmailMetadata {
-            message_id,
-            sender: from,
-            recipient: rcpt,
-            subject,
-            path: file_path.clone(),
-        };
+        let metadata = EmailMetadata::new(message_id, from, rcpt, subject, file_path.clone());
         let db_path = crate_root.join("mailbox").join("metadata.db");
-        store_metadata(db_path, &metadata).await?;
+        metadata.store_sqlite(db_path).await?;
     }
     Ok(())
 }

--- a/smtp/src/main.rs
+++ b/smtp/src/main.rs
@@ -355,7 +355,7 @@ impl SMTPSession {
             message
         );
         writer
-            .write_all(format!("{}{}{}\r\n", code, separator, message).as_bytes())
+            .write_all(format!("{code}{separator}{message}\r\n").as_bytes())
             .await
             .ok();
     }
@@ -406,7 +406,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|_| PORT.to_string())
         .parse()
         .unwrap();
-    let listening = format!("{}:{}", host, port);
+    let listening = format!("{host}:{port}");
     let listener = TcpListener::bind(&listening).await?;
 
     let tls_acceptor = TlsAcceptor::from(tls_config);
@@ -419,7 +419,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         while let Some((from, rcpts, body)) = rx.recv().await {
             for rcpt in rcpts {
                 if let Err(error) = store_email(from.clone(), rcpt, body.clone(), true).await {
-                    println!("Error storing email: {}", error);
+                    println!("Error storing email: {error}");
                 }
             }
         }
@@ -494,7 +494,7 @@ async fn handle_stream(
                         return handle_tls_stream(TlsStream::Server(tls_stream), tx, session).await;
                     }
                     Err(e) => {
-                        eprintln!("TLS handshake failed: {:?}", e);
+                        eprintln!("TLS handshake failed: {e:?}");
                         return Ok(());
                     }
                 }
@@ -581,21 +581,21 @@ async fn store_email(
     let crate_root = get_crate_root().unwrap_or(PathBuf::from_str(".").unwrap());
     let path = crate_root.join("mailbox").join(&safe_rcpt);
     fs::create_dir_all(&path).await?;
-    let id = Uuid::new_v4().to_string();
-    let file_path = path.join(format!("{}.eml", id));
+    let message_id = Uuid::new_v4().to_string();
+    let file_path = path.join(format!("{message_id}.eml"));
     let file_path_str = file_path.to_str().unwrap();
     let mut file = File::create(&file_path).await?;
-    println!("Started storing email to {}", file_path_str);
+    println!("Started storing email to {file_path_str}");
     if !is_mime_valid(&body).await {
-        file.write_all(format!("From: {}\r\n", from).as_bytes())
+        file.write_all(format!("From: {from}\r\n").as_bytes())
             .await?;
-        file.write_all(format!("To: {}\r\n", rcpt).as_bytes())
+        file.write_all(format!("To: {rcpt}\r\n").as_bytes())
             .await?;
         file.write_all(format!("Date: {}\r\n\r\n", Utc::now().to_rfc2822()).as_bytes())
             .await?;
     }
     file.write_all(body.as_bytes()).await?;
-    println!("Stored: {}", file_path_str);
+    println!("Stored: {file_path_str}");
 
     // checks if the metadata should be stored, if so, it will
     // parse the headers and store the metadata in the database
@@ -603,7 +603,7 @@ async fn store_email(
         let headers = parse_mime_headers(&body).unwrap_or_default();
         let subject = headers.get("Subject").cloned().unwrap_or_default();
         let metadata = EmailMetadata {
-            id,
+            message_id,
             sender: from,
             recipient: rcpt,
             subject,


### PR DESCRIPTION
## Summary
- support SQLite for metadata
- parse MIME headers to capture subject
- store metadata alongside email in `metadata.db`

Closes #3 

## Testing
- `cargo check`
- `cargo check --workspace`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684ebb4a489483288e77525f52f71cdc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for extracting and storing email metadata (ID, sender, recipient, subject, file path) in a SQLite database for each received email.

- **Bug Fixes**
  - Improved error handling when storing emails by updating function signatures to return more comprehensive error types.

- **Improvements**
  - Modernized string formatting across multiple components for clearer and more consistent output messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->