### PR TITLE
Audit for unneeded clones

### DIFF
--- a/imap/src/main.rs
+++ b/imap/src/main.rs
@@ -57,7 +57,7 @@ impl IMAPSession {
     ) -> Result<(), Box<dyn Error>> {
         if parts.len() >= 4 {
             self.authenticated = true;
-            self.username = Some(parts[2].to_string().trim_matches('"').to_string());
+            self.username = Some(parts[2].trim_matches('"').to_string());
             self.write_response(writer, tag, "OK", "LOGIN completed")
                 .await?;
         } else {
@@ -154,11 +154,10 @@ impl IMAPSession {
         parts: &[&str],
     ) -> Result<(), Box<dyn Error>> {
         if parts.len() >= 4 {
-            let message_id = parts[2].to_string();
+            let message_id = parts[2];
             let message_sequence = 1;
-            let format = parts[3].to_string();
-            let format_inner = format[1..format.len() - 1].to_string();
-            let message = self.fetch_message(&message_id).await?;
+            let format_inner = &parts[3][1..parts[3].len() - 1];
+            let message = self.fetch_message(message_id).await?;
             self.write_response(
                 writer,
                 "*",
@@ -261,7 +260,7 @@ impl IMAPSession {
         // the string based IMAP range into a rust one
         let range = uid_fetch_range_str(parts[3], messages.len() as u32).ok_or("Invalid range")?;
         let (start, end) = ((*range.start() - 1) as usize, (*range.end() - 1) as usize);
-        let messages_range = messages[start..=end].to_vec();
+        let messages_range = &messages[start..=end];
 
         // Save the message indices in a hashmap for faster lookup
         let message_indices: std::collections::HashMap<_, _> = messages
@@ -273,31 +272,22 @@ impl IMAPSession {
         for message in messages_range {
             let index = message_indices[&message];
             let contents = self.fetch_message(&message).await.unwrap();
-            let slices = parts[4..parts.len()]
+            let slices = parts[4..]
                 .iter()
-                .map(|s| {
-                    let s = s.to_string();
-                    let s = s.trim_matches('(').trim_matches(')');
-                    match s {
-                        "FLAGS" => "FLAGS (\\Unseen)".to_string(),
-                        "RFC822.SIZE" => format!("RFC822.SIZE {}", message.len()),
-                        "BODY.PEEK[HEADER.FIELDS" => {
-                            format!(
-                                "BODY[HEADER.FIELDS (To From Subject)] {{{}}}\r\n{}",
-                                contents.len(),
-                                contents
-                            )
-                        }
-                        "BODY[]" => {
-                            format!("BODY[] {{{}}}\r\n{}", contents.len(), contents)
-                        }
-                        _ => "".to_string(),
+                .filter_map(|s| {
+                    let trimmed = s.trim_matches(['(', ')']);
+                    match trimmed {
+                        "FLAGS" => Some("FLAGS (\\Unseen)".to_string()),
+                        "RFC822.SIZE" => Some(format!("RFC822.SIZE {}", message.len())),
+                        "BODY.PEEK[HEADER.FIELDS" => Some(format!(
+                            "BODY[HEADER.FIELDS (To From Subject)] {{{}}}\r\n{}",
+                            contents.len(),
+                            contents
+                        )),
+                        "BODY[]" => Some(format!("BODY[] {{{}}}\r\n{}", contents.len(), contents)),
+                        _ => None,
                     }
                 })
-                .collect::<Vec<String>>()
-                .iter()
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
                 .collect::<Vec<String>>()
                 .join(" ");
             self.write_response(
@@ -394,7 +384,7 @@ impl IMAPSession {
 
     fn safe_username(&self) -> String {
         self.username
-            .clone()
+            .as_deref()
             .unwrap_or_default()
             .replace(|c: char| !c.is_ascii_alphanumeric(), "_")
     }

--- a/smtp/src/main.rs
+++ b/smtp/src/main.rs
@@ -294,12 +294,11 @@ impl SMTPSession {
         }
 
         let data = String::from_utf8_lossy(&buffer_data).into_owned();
+        let from = std::mem::take(&mut self.from);
+        let rcpts = std::mem::take(&mut self.rcpts);
 
-        let _ = tx.send((self.from.clone(), self.rcpts.clone(), data)).await;
+        let _ = tx.send((from, rcpts, data)).await;
         self.write_response(writer, 250, "Message accepted").await;
-
-        self.from.clear();
-        self.rcpts.clear();
 
         Ok(())
     }
@@ -417,7 +416,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tokio::spawn(async move {
         while let Some((from, rcpts, body)) = rx.recv().await {
             for rcpt in rcpts {
-                if let Err(error) = store_email(from.clone(), rcpt, body.clone(), true).await {
+                if let Err(error) = store_email(&from, &rcpt, &body, true).await {
                     println!("Error storing email: {error}");
                 }
             }
@@ -571,9 +570,9 @@ fn load_credentials(path: &str) -> HashMap<String, String> {
 ///
 /// There's no limit to the number of emails that can be stored.
 async fn store_email(
-    from: String,
-    rcpt: String,
-    body: String,
+    from: &str,
+    rcpt: &str,
+    body: &str,
     store_meta: bool,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let safe_rcpt = rcpt.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
@@ -585,7 +584,7 @@ async fn store_email(
     let file_path_str = file_path.to_str().unwrap();
     let mut file = File::create(&file_path).await?;
     println!("Started storing email to {file_path_str}");
-    if !is_mime_valid(&body).await {
+    if !is_mime_valid(body).await {
         file.write_all(format!("From: {from}\r\n").as_bytes())
             .await?;
         file.write_all(format!("To: {rcpt}\r\n").as_bytes()).await?;
@@ -598,9 +597,15 @@ async fn store_email(
     // checks if the metadata should be stored, if so, it will
     // parse the headers and store the metadata in the database
     if store_meta {
-        let headers = parse_mime_headers(&body).unwrap_or_default();
+        let headers = parse_mime_headers(body).unwrap_or_default();
         let subject = headers.get("Subject").cloned().unwrap_or_default();
-        let metadata = EmailMetadata::new(message_id, from, rcpt, subject, file_path.clone());
+        let metadata = EmailMetadata::new(
+            message_id,
+            from.to_string(),
+            rcpt.to_string(),
+            subject,
+            file_path.clone(),
+        );
         let db_path = crate_root.join("mailbox").join("metadata.db");
         metadata.store_sqlite(db_path).await?;
     }


### PR DESCRIPTION
## Summary
- trim string allocations in `IMAPSession::handle_login`
- avoid allocating intermediate strings in `handle_fetch` and `handle_uid_fetch`
- derive username safely without cloning
- remove cloning in SMTP data handling and when storing emails
- update email storage helper to use string slices

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685337a85500832889e2c5be055159f1