### PR TITLE
Add SMTP server unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Added unit tests for the SMTP server

--- a/crates/utils/src/metadata.rs
+++ b/crates/utils/src/metadata.rs
@@ -149,7 +149,7 @@ mod tests {
         );
 
         let result = metadata.store_sqlite(db_path).await;
-        assert!(result.is_ok(), "Failed to store metadata: {:?}", result);
+        assert!(result.is_ok(), "Failed to store metadata: {result:?}");
 
         let conn = Connection::open(db_path).unwrap();
         let mut stmt = conn
@@ -199,11 +199,7 @@ mod tests {
         );
 
         let result1 = metadata1.store_sqlite(db_path).await;
-        assert!(
-            result1.is_ok(),
-            "First insert should succeed: {:?}",
-            result1
-        );
+        assert!(result1.is_ok(), "First insert should succeed: {result1:?}");
 
         let result2 = metadata2.store_sqlite(db_path).await;
         assert!(
@@ -234,10 +230,10 @@ mod tests {
         );
 
         let result1 = metadata1.store_sqlite(db_path).await;
-        assert!(result1.is_ok(), "First insert failed: {:?}", result1);
+        assert!(result1.is_ok(), "First insert failed: {result1:?}");
 
         let result2 = metadata2.store_sqlite(db_path).await;
-        assert!(result2.is_ok(), "Second insert failed: {:?}", result2);
+        assert!(result2.is_ok(), "Second insert failed: {result2:?}");
 
         let conn = Connection::open(db_path).unwrap();
         let count: i64 = conn
@@ -263,8 +259,7 @@ mod tests {
         let result = metadata.store_sqlite(db_path).await;
         assert!(
             result.is_ok(),
-            "Failed to store metadata with special characters: {:?}",
-            result
+            "Failed to store metadata with special characters: {result:?}"
         );
 
         let conn = Connection::open(db_path).unwrap();
@@ -327,8 +322,7 @@ mod tests {
         let store_result = original_metadata.store_sqlite(db_path).await;
         assert!(
             store_result.is_ok(),
-            "Failed to store metadata: {:?}",
-            store_result
+            "Failed to store metadata: {store_result:?}"
         );
 
         // Then retrieve it
@@ -336,8 +330,7 @@ mod tests {
             EmailMetadata::retrieve_sqlite(db_path, "retrieve-test-id".to_string()).await;
         assert!(
             retrieved_metadata.is_ok(),
-            "Failed to retrieve metadata: {:?}",
-            retrieved_metadata
+            "Failed to retrieve metadata: {retrieved_metadata:?}"
         );
 
         let retrieved = retrieved_metadata.unwrap();

--- a/smtp/src/main.rs
+++ b/smtp/src/main.rs
@@ -614,3 +614,88 @@ async fn store_email(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, BufReader};
+
+    #[tokio::test]
+    async fn test_handle_ehlo_helo_writes_greeting() {
+        let creds = Arc::new(HashMap::new());
+        let session = SMTPSession::new(creds, false);
+
+        let (mut client, mut server) = duplex(1024);
+        session.handle_ehlo_helo(&mut server).await.unwrap();
+        drop(server);
+
+        let mut output = String::new();
+        client.read_to_string(&mut output).await.unwrap();
+        assert_eq!(
+            output,
+            "250-localhost greets you\r\n250-STARTTLS\r\n250 AUTH LOGIN\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_auth_login_success() {
+        let mut map = HashMap::new();
+        map.insert("user".to_string(), "pass".to_string());
+        let creds = Arc::new(map);
+        let mut session = SMTPSession::new(creds, false);
+
+        let encoded_user = general_purpose::STANDARD.encode("user");
+        let encoded_pass = general_purpose::STANDARD.encode("pass");
+        let input = format!("{encoded_user}\r\n{encoded_pass}\r\n");
+
+        let (client, server) = duplex(1024);
+        let (mut client_read, mut client_write) = tokio::io::split(client);
+        let (server_read, mut server_write) = tokio::io::split(server);
+        let mut reader = BufReader::new(server_read);
+        let write_task = tokio::spawn(async move {
+            client_write.write_all(input.as_bytes()).await.unwrap();
+            drop(client_write);
+        });
+
+        let mut line = String::new();
+        session
+            .handle_auth_login(&mut reader, &mut server_write, &mut line)
+            .await
+            .unwrap();
+        drop(server_write);
+        drop(reader);
+        write_task.await.unwrap();
+
+        let mut output = String::new();
+        client_read.read_to_string(&mut output).await.unwrap();
+        assert!(session.authenticated);
+        assert_eq!(
+            output,
+            "334 VXNlcm5hbWU6\r\n334 UGFzc3dvcmQ6\r\n235 Authentication successful\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_mail_and_rcpt_adds_addresses() {
+        let creds = Arc::new(HashMap::new());
+        let mut session = SMTPSession::new(creds, false);
+
+        let (mut client, mut server) = duplex(1024);
+        session
+            .handle_mail(&mut server, "FROM:<sender@example.com>")
+            .await
+            .unwrap();
+        session
+            .handle_rcpt(&mut server, "TO:<recipient@example.com>")
+            .await
+            .unwrap();
+        drop(server);
+
+        let mut output = String::new();
+        client.read_to_string(&mut output).await.unwrap();
+
+        assert_eq!(session.from, "sender@example.com");
+        assert!(session.rcpts.contains("recipient@example.com"));
+        assert_eq!(output, "250 OK\r\n250 OK\r\n");
+    }
+}


### PR DESCRIPTION
## Summary
- create CHANGELOG with unreleased entry
- add SMTP session unit tests
- address clippy suggestions

## Testing
- `cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets`
- `black .`
- `RUST_TEST_THREADS=1 cargo test --all-targets --all-features -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685827f1e32c8328af76df0435fd3b7e